### PR TITLE
Fix incorrect command name in scheduler.

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
          $schedule->command('ChooseRandomVictim')->everyMinute();
-         $schedule->command('SendReminderNotifications')->everyMinute();
+         $schedule->command('app:send-reminder-notifications')->everyMinute();
     }
 
     /**


### PR DESCRIPTION
Class name was called but the command signature was app:send-reminder-notifications. 